### PR TITLE
Fix package.json resolution with custom server entry

### DIFF
--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -844,25 +844,25 @@ export async function resolveEntryFiles({
   let entryServerFile: string;
   let entryClientFile = userEntryClientFile || "entry.client.tsx";
 
-  let packageJsonPath = findEntry(rootDirectory, "package", {
-    extensions: [".json"],
-    absolute: true,
-    walkParents: true,
-  });
-
-  if (!packageJsonPath) {
-    throw new Error(
-      `Could not find package.json in ${rootDirectory} or any of its parent directories`
-    );
-  }
-
-  let packageJsonDirectory = Path.dirname(packageJsonPath);
-  let pkgJson = await PackageJson.load(packageJsonDirectory);
-  let deps = pkgJson.content.dependencies ?? {};
-
   if (userEntryServerFile) {
     entryServerFile = userEntryServerFile;
   } else {
+    let packageJsonPath = findEntry(rootDirectory, "package", {
+      extensions: [".json"],
+      absolute: true,
+      walkParents: true,
+    });
+
+    if (!packageJsonPath) {
+      throw new Error(
+        `Could not find package.json in ${rootDirectory} or any of its parent directories`
+      );
+    }
+
+    let packageJsonDirectory = Path.dirname(packageJsonPath);
+    let pkgJson = await PackageJson.load(packageJsonDirectory);
+    let deps = pkgJson.content.dependencies ?? {};
+
     if (!deps["@react-router/node"]) {
       throw new Error(
         `Could not determine server runtime. Please install @react-router/node, or provide a custom entry.server.tsx/jsx file in your app directory.`


### PR DESCRIPTION
## Summary
- skip package.json dependency checks when a user-supplied `entry.server` file is present

## Testing
- `pnpm build`
- `pnpm test --silent` *(fails: CopyTemplateError – received 403)*

------
https://chatgpt.com/codex/tasks/task_e_683f6b0958a48320bc5060cdb4f606a0